### PR TITLE
Reorganize NewSongForm to use version of fractal structure.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,9 @@
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "deploy": "npm run build && firebase deploy"
+  },
+  "devDependencies": {
+    "enzyme": "^3.2.0",
+    "enzyme-adapter-react-16": "^1.1.0"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -4,12 +4,14 @@ import store from 'store'
 import 'typeface-roboto'
 import './App.css'
 import Header from 'components/Header'
+import NewSong from 'components/NewSong'
 import SongList from './components/SongList'
 
 const App = () =>
   <ReduxProvider store={ store }>
     <div className='App'>
       <Header />
+      <NewSong />
       <SongList />
     </div>
   </ReduxProvider>

--- a/src/components/Header/Header.test.js
+++ b/src/components/Header/Header.test.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import Header from './Header'
+
+it('renders the title prop as text', () => {
+  const testTitle = "Hello world"
+  const wrapper = shallow(<Header title={ testTitle } />)
+
+  expect(wrapper.text()).toBe(testTitle)
+})

--- a/src/components/NewSong/NewSong.js
+++ b/src/components/NewSong/NewSong.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import NewSongForm from './NewSongForm'
+
+const styles = {
+  container: {
+    marginTop: 20,
+    textAlign: 'center',
+  },
+}
+
+const NewSong = ({ isEditing, toggleIsEditing }) =>
+  <div style={ styles.container }>
+    {
+      isEditing
+        ? <NewSongForm />
+        : <button onClick={toggleIsEditing}>New Song</button>
+    }
+  </div>
+
+NewSong.propTypes = {
+  isEditing: PropTypes.bool.isRequired,
+  toggleIsEditing: PropTypes.func.isRequired,
+}
+
+export default NewSong

--- a/src/components/NewSong/NewSong.test.js
+++ b/src/components/NewSong/NewSong.test.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import NewSong from './NewSong'
+import NewSongForm from './NewSongForm'
+
+it('renders a <button> when isEditing is false', () => {
+  const wrapper = shallow(<NewSong isEditing={ false } toggleIsEditing={ () => {} } />)
+
+  expect(wrapper.find('button').length).toBe(1)
+  expect(wrapper.find(NewSongForm).length).toBe(0)
+})
+
+it('renders a <NewSongForm> when isEditing is true', () => {
+  const wrapper = shallow(<NewSong isEditing={ true } toggleIsEditing={ () => {} } />)
+
+  expect(wrapper.find(NewSongForm).length).toBe(1)
+  expect(wrapper.find('button').length).toBe(0)
+})
+
+it('calls toggleIsEditing when <button> is clicked', () => {
+  const toggleIsEditingMock = jest.fn()
+
+  const wrapper = shallow(<NewSong isEditing={ false } toggleIsEditing={ toggleIsEditingMock } />)
+
+  expect(toggleIsEditingMock).not.toHaveBeenCalled()
+
+  wrapper.find('button').first().simulate('click')
+
+  expect(toggleIsEditingMock).toHaveBeenCalled()
+})

--- a/src/components/NewSong/NewSongForm/NewSongForm.js
+++ b/src/components/NewSong/NewSongForm/NewSongForm.js
@@ -42,7 +42,6 @@ class NewSongForm extends Component {
 const styles = {
   newSongFormStyles: {
     fontSize: '1.2em',
-    textAlign: 'center'
   }
 }
 

--- a/src/components/NewSong/NewSongForm/index.js
+++ b/src/components/NewSong/NewSongForm/index.js
@@ -1,0 +1,5 @@
+import NewSongForm from './NewSongForm'
+
+// TODO: refactor NewSongForm to use redux and apply react-redux `connect` here
+
+export default NewSongForm

--- a/src/components/NewSong/index.js
+++ b/src/components/NewSong/index.js
@@ -1,0 +1,12 @@
+import { connect } from 'react-redux'
+import { toggleIsEditing } from 'store/newSong/actions'
+import NewSong from './NewSong'
+
+export default connect(
+  ({ newSong }) => ({
+    isEditing: newSong.isEditing,
+  }),
+  {
+    toggleIsEditing,
+  }
+)(NewSong)

--- a/src/components/SongList/SongList.js
+++ b/src/components/SongList/SongList.js
@@ -1,20 +1,12 @@
-import NewSongForm from 'components/NewSongForm'
 import Song from 'components/Song/Song'
 import PropTypes from 'prop-types'
 import React from 'react'
 
 const SongList = ({
                     changeVote,
-                    isEditing,
                     songs,
-                    toggleIsEditing,
                   }) => (
   <div style={styles.songListStyles}>
-    {
-      isEditing
-        ? <NewSongForm />
-        : <button onClick={toggleIsEditing}>New Song</button>
-    }
     {
       songs.map(
         song => <Song key={song.id} changeVote={changeVote(song)} song={song} />
@@ -25,7 +17,6 @@ const SongList = ({
 
 SongList.propTypes = {
   changeVote: PropTypes.func.isRequired,
-  isEditing: PropTypes.bool.isRequired,
   songs: PropTypes.arrayOf(
     PropTypes.shape({
       album: PropTypes.string,
@@ -35,7 +26,6 @@ SongList.propTypes = {
       votes: PropTypes.number,
     })
   ).isRequired,
-  toggleIsEditing: PropTypes.func.isRequired,
 }
 
 const styles = {

--- a/src/components/SongList/index.js
+++ b/src/components/SongList/index.js
@@ -8,7 +8,6 @@ import { compose } from 'redux'
 import { connect } from 'react-redux'
 import { firebaseConnect } from 'react-redux-firebase'
 import { changeVote } from 'store/songs/actions'
-import { toggleIsEditing } from 'store/newSong/actions'
 import SongList from './SongList'
 
 const sortDescByVotes = compose(
@@ -23,13 +22,11 @@ export default compose(
     'songs'
   ]),
   connect(
-    ({ firebase, newSong }) => ({
-      isEditing: newSong.isEditing,
+    ({ firebase }) => ({
       songs: sortDescByVotes(firebase.data.songs),
     }),
     {
       changeVote,
-      toggleIsEditing,
     }
   )
 )(SongList)

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,4 @@
+import { configure } from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
+
+configure({ adapter: new Adapter() })


### PR DESCRIPTION
I pulled the `NewSongForm` out of the `SongList` to give an example of what I think is a simpler fractal file pattern, as well as to prepare for the redux refactor of that component.

```
components/
  NewSong/
    index.js -- exports NewSong, (optionally) describes how to get data to NewSong.js as props
    NewSong.js -- describes how to get from `props` to a DOM representation, renders NewSongForm as a child
    NewSong.test.js -- tests NewSong.js
    NewSongForm/
      index.js
      NewSongForm.js
      NewSongForm.test.js (not implemented)
```

So, this file structure mimics the structure of the DOM representation we are producing, with all components dirs having the same
```
ComponentName/
  index.js -- possibly enhanced
  ComponentName.js -- primitive
  ComponentName.test.js -- test of primitive
  ComponentChild/
    ...
```
pattern.

Feel free to disagree, but I think the camelCase dir introduced in the other fractal structure proposal makes the tree less intuitive/predictable.