### PR TITLE
UI feedback - About page and Show pages

### DIFF
--- a/src/components/About/About.jsx
+++ b/src/components/About/About.jsx
@@ -11,13 +11,10 @@ import {
 import Button from "../common/Button"
 import styled, { keyframes } from "styled-components"
 import TipJar from "./TipJar"
-
 const About = () => {
   return (
     <AboutContainer>
       <Header title={"About Me"} />
-
-      <TipJar />
 
       <ContentWrapper>
         <ProfileSection>
@@ -38,16 +35,17 @@ const About = () => {
               <FontAwesomeIcon icon={faMicrophone} />
             </MusicIcon>
           </MusicIconsContainer>
-        </ProfileSection>
-
-        <BioSection>
           <BioText>
             I am a singer & guitar player in the Atlanta, Georgia area where I
             perform acoustic covers at local restaurants and private events.
             Thank you for using this app! I hope it will be a fun way for us to
             interact during our time together.
           </BioText>
+        </ProfileSection>
 
+        <TipJar />
+
+        <BioSection>
           <Highlight>
             Grab some food, pull up a chair, and let's sing some songs.
           </Highlight>
@@ -125,7 +123,6 @@ const ProfileSection = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-bottom: 2rem;
 `
 
 const ProfileImageContainer = styled.div`
@@ -179,13 +176,11 @@ const MusicIcon = styled.div`
 
 const BioSection = styled.div`
   text-align: center;
-  margin-bottom: 2.5rem;
 `
 
 const BioText = styled.p`
   font-size: 1.1rem;
   line-height: 1.6;
-  margin-bottom: 1.5rem;
   color: var(--text-secondary);
 `
 
@@ -193,7 +188,6 @@ const Highlight = styled.p`
   font-size: 1.2rem;
   font-weight: 500;
   color: var(--text-primary);
-  margin-bottom: 1rem;
   padding: 0.5rem 1rem;
   border-left: 3px solid var(--primary);
   border-right: 3px solid var(--primary);
@@ -211,8 +205,6 @@ const SocialSection = styled.div`
   display: flex;
   justify-content: center;
   gap: 1.5rem;
-  margin-top: auto;
-  padding-bottom: 2rem;
 `
 
 const SocialLink = styled.a`

--- a/src/components/About/TipJar.jsx
+++ b/src/components/About/TipJar.jsx
@@ -29,7 +29,6 @@ const TipJar = () => {
   )
 }
 
-// Animations
 const pulse = keyframes`
   0% { transform: scale(1); }
   50% { transform: scale(1.3); }
@@ -42,24 +41,22 @@ const float = keyframes`
   100% { transform: translateY(0); }
 `
 
-// Styled Components
 const TipJarContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 1.5rem;
-  margin: 1.5rem 0;
   background: rgba(255, 255, 255, 0.05);
   backdrop-filter: blur(10px);
   border-radius: 16px;
   border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 0.5rem 1rem;
 `
 
 const TipJarTitle = styled.h3`
   font-size: 1.4rem;
   font-weight: 600;
   color: var(--text-primary);
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
   display: flex;
   align-items: center;
   gap: 0.8rem;
@@ -76,7 +73,7 @@ const TipJarDescription = styled.p`
   line-height: 1.5;
   text-align: center;
   color: var(--text-secondary);
-  margin-bottom: 1.5rem;
+  margin-bottom: 1rem;
   max-width: 90%;
 `
 

--- a/src/components/Shows/DeleteShow.jsx
+++ b/src/components/Shows/DeleteShow.jsx
@@ -24,7 +24,7 @@ export const DeleteShow = ({ show }) => {
 
 const DeleteButton = styled.button`
   background: transparent;
-  color: rgba(255, 59, 48, 0.8);
+  color: var(--text-secondary);
   border: none;
   display: flex;
   align-items: center;

--- a/src/components/Shows/Shows.jsx
+++ b/src/components/Shows/Shows.jsx
@@ -42,5 +42,4 @@ const ShowsContainer = styled.div`
   align-items: center;
   justify-content: center;
   margin-bottom: 15vh;
-  padding: 0 16px;
 `


### PR DESCRIPTION
> On the Shows page, can you adjust the width of the calendar’s background frame to match the width of the events below it?  Oddly, it looked the same width on my laptop but not on my phone. 

> On the shows page in Edit mode. Can you change the delete icon to match the color and styling of the delete icon that’s on the Songs page?

> On the About Me page, the tip jar is a great addition!  Can you narrow the width of the background frame around it to align with other content on the page?
Lastly, I’d like the text introduction to be the first thing on the page. Can you swap it with the tip jar section and leave that cool randy godwin quote below it all?

