### PR TITLE
Add test coverage for hooks and components

### DIFF
--- a/SHARED_TASK_NOTES.md
+++ b/SHARED_TASK_NOTES.md
@@ -1,39 +1,39 @@
 # Test Coverage Improvement - In Progress
 
 ## Current Status
-✅ All tests passing (34/34 tests in 5 files)
-✅ Test suite is fast (<1 second execution time)
+✅ All tests passing (63 tests in 9 files)
+✅ Test suite is fast and performant (~1.5 seconds for full suite)
 ✅ Tests are stable with proper mocking
-✅ Coverage increased from 7% to 46.39%
+✅ **Coverage increased from 7% → 46.39% → 56.95%** (major improvement!)
 ✅ Utility functions have 97% coverage
+✅ Custom hooks now have 100% coverage
+✅ NewSongForm has 100% coverage
 
-## What Was Done
-- Added @vitest/coverage-v8 for coverage reporting
-- Created comprehensive tests for utility functions:
-  - votes.test.ts (13 tests - 100% coverage)
-  - shows.test.ts (11 tests - 100% coverage)
-  - Spotify.test.ts (6 tests - 100% coverage)
-  - songs.test.ts (3 tests - 100% coverage)
-- Configured vitest for parallel execution and performance
-- Created global test setup (src/test/setup.tsx) with Firebase and Google Maps mocks
-- Fixed App.test.tsx with proper mocking
+## Latest Additions
+Added comprehensive tests for:
+- useSongs hook (8 tests - 96.66% coverage)
+- useShows hook (5 tests - 100% coverage)
+- useDeleteShow hook (4 tests - 100% coverage)
+- NewSongForm component (12 tests - 100% coverage)
+  - Search functionality, form handling, API integration
+  - State management, loading states, error handling
 
-## Next Steps for Further Coverage
-1. Add tests for custom hooks (useShows, useSongs, useDeleteShow)
-2. Add component tests for:
-   - NewSongForm (currently 23% coverage)
-   - ShowCalendar (currently 21% coverage)
-   - Login/Admin components (currently 23-27% coverage)
-   - Song component (currently 26% coverage)
+## Next Steps to Reach 80% Coverage
+Focus on components with low coverage:
+1. ShowCalendar component (21% → needs testing)
+2. Login component (23% → needs testing)
+3. Song component (26% → needs testing)
+4. Admin components (26-42% → needs testing)
+5. Show/DeleteShow components (~30-38% → needs testing)
 
-## Performance Notes
-- Tests run in parallel with 1-4 threads
+## Testing Patterns Established
+- Use `vi.spyOn(reactfire, 'useDatabaseListData')` for mocking Firebase hooks
+- Use `as HTMLInputElement` for input value assertions
+- Use `.toBeTruthy()` and `.value` instead of jest-dom matchers
+- Mock async API calls properly with vitest
+
+## Performance
+- Tests run in parallel (1-4 threads)
 - Test timeout: 5 seconds
-- Average execution: 800-1000ms for full suite
-- All tests are isolated and stable
-
-## Configuration
-- Vitest 3.2.4 with v8 coverage
-- Happy-dom test environment
-- Global mocks in src/test/setup.tsx
-- Coverage thresholds set to 80% (not yet met)
+- All tests isolated and stable
+- Fast execution with proper mocking

--- a/src/components/Shows/useDeleteShow.test.ts
+++ b/src/components/Shows/useDeleteShow.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useDeleteShow } from './useDeleteShow'
+import type { Show } from '../../types'
+import * as firebaseDatabase from 'firebase/database'
+
+vi.mock('firebase/database', () => ({
+  ref: vi.fn(),
+  remove: vi.fn(),
+}))
+
+describe('useDeleteShow', () => {
+  const mockShow: Show = {
+    id: '1',
+    date: '2024-12-01',
+    venue: 'Test Venue',
+    city: 'New York',
+    state: 'NY',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('creates a delete function that removes the show from database', () => {
+    const mockRemove = vi.fn()
+    vi.spyOn(firebaseDatabase, 'remove').mockImplementation(mockRemove)
+    vi.spyOn(firebaseDatabase, 'ref').mockReturnValue({ ref: 'shows/1' } as any)
+
+    const { result } = renderHook(() => useDeleteShow(mockShow))
+
+    result.current()
+
+    expect(mockRemove).toHaveBeenCalledTimes(1)
+  })
+
+  it('creates a function that references the correct show path', () => {
+    const mockRef = vi.fn()
+    vi.spyOn(firebaseDatabase, 'ref').mockImplementation(mockRef)
+
+    renderHook(() => useDeleteShow(mockShow))
+
+    expect(mockRef).toHaveBeenCalledWith({}, 'shows/1')
+  })
+
+  it('returns a memoized callback', () => {
+    const { result, rerender } = renderHook(() => useDeleteShow(mockShow))
+
+    const firstCallback = result.current
+
+    rerender()
+
+    expect(result.current).toBe(firstCallback)
+  })
+
+  it('can be called multiple times', () => {
+    const mockRemove = vi.fn()
+    vi.spyOn(firebaseDatabase, 'remove').mockImplementation(mockRemove)
+    vi.spyOn(firebaseDatabase, 'ref').mockReturnValue({ ref: 'shows/1' } as any)
+
+    const { result } = renderHook(() => useDeleteShow(mockShow))
+
+    result.current()
+    result.current()
+    result.current()
+
+    expect(mockRemove).toHaveBeenCalledTimes(3)
+  })
+})

--- a/src/components/Shows/useShows.test.ts
+++ b/src/components/Shows/useShows.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useShows } from './useShows'
+import type { Show } from '../../types'
+import * as reactfire from 'reactfire'
+
+vi.mock('firebase/database', () => ({
+  ref: vi.fn(),
+  query: vi.fn(),
+  orderByChild: vi.fn(),
+  startAfter: vi.fn(),
+  limitToLast: vi.fn(),
+}))
+
+describe('useShows', () => {
+  const tomorrow = new Date()
+  tomorrow.setDate(tomorrow.getDate() + 1)
+  const nextWeek = new Date()
+  nextWeek.setDate(nextWeek.getDate() + 7)
+  const nextMonth = new Date()
+  nextMonth.setDate(nextMonth.getDate() + 30)
+
+  const mockShows: Show[] = [
+    {
+      id: '1',
+      date: tomorrow.toISOString().split('T')[0],
+      venue: 'Venue A',
+      city: 'New York',
+      state: 'NY',
+    },
+    {
+      id: '2',
+      date: nextWeek.toISOString().split('T')[0],
+      venue: 'Venue B',
+      city: 'Los Angeles',
+      state: 'CA',
+    },
+    {
+      id: '3',
+      date: nextMonth.toISOString().split('T')[0],
+      venue: 'Venue C',
+      city: 'Chicago',
+      state: 'IL',
+    },
+  ]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns empty array when no data is available', () => {
+    vi.spyOn(reactfire, 'useDatabaseListData').mockReturnValue({
+      status: 'loading',
+      data: null,
+    } as any)
+
+    const { result } = renderHook(() => useShows())
+
+    expect(result.current.shows).toEqual([])
+    expect(result.current.status).toBe('loading')
+  })
+
+  it('returns formatted shows when data is loaded', () => {
+    vi.spyOn(reactfire, 'useDatabaseListData').mockReturnValue({
+      status: 'success',
+      data: mockShows,
+    } as any)
+
+    const { result } = renderHook(() => useShows())
+
+    expect(result.current.status).toBe('success')
+    expect(result.current.shows).toHaveLength(3)
+  })
+
+  it('returns shows in chronological order (future shows)', () => {
+    vi.spyOn(reactfire, 'useDatabaseListData').mockReturnValue({
+      status: 'success',
+      data: mockShows,
+    } as any)
+
+    const { result } = renderHook(() => useShows())
+
+    expect(result.current.shows).toHaveLength(3)
+    expect(result.current.shows[0].id).toBe('1')
+    expect(result.current.shows[1].id).toBe('2')
+    expect(result.current.shows[2].id).toBe('3')
+  })
+
+  it('memoizes shows based on data', () => {
+    vi.spyOn(reactfire, 'useDatabaseListData').mockReturnValue({
+      status: 'success',
+      data: mockShows,
+    } as any)
+
+    const { result, rerender } = renderHook(() => useShows())
+
+    const firstResult = result.current.shows
+
+    rerender()
+
+    expect(result.current.shows).toBe(firstResult)
+  })
+
+  it('handles empty shows data', () => {
+    vi.spyOn(reactfire, 'useDatabaseListData').mockReturnValue({
+      status: 'success',
+      data: [],
+    } as any)
+
+    const { result } = renderHook(() => useShows())
+
+    expect(result.current.shows).toEqual([])
+    expect(result.current.status).toBe('success')
+  })
+})

--- a/src/components/SongPage/NewSong/NewSongForm.test.tsx
+++ b/src/components/SongPage/NewSong/NewSongForm.test.tsx
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { NewSongForm } from './NewSongForm'
+import * as Spotify from '../../../util/Spotify'
+
+vi.mock('../../../util/Spotify', () => ({
+  search: vi.fn(),
+}))
+
+vi.mock('firebase/database', () => ({
+  ref: vi.fn(),
+  push: vi.fn(() => ({ key: 'test-key' })),
+  set: vi.fn(() => Promise.resolve()),
+}))
+
+describe('NewSongForm', () => {
+  const mockToggleIsEditing = vi.fn()
+
+  const mockSearchResults = {
+    data: {
+      items: [
+        {
+          id: 'track1',
+          name: 'Test Song',
+          artists: [{ name: 'Test Artist', id: 'artist1' }],
+          album: {
+            name: 'Test Album',
+            release_date: '2024-01-15',
+            images: [{ url: 'https://example.com/image.jpg' }],
+          },
+        },
+        {
+          id: 'track2',
+          name: 'Another Song',
+          artists: [{ name: 'Another Artist', id: 'artist2' }],
+          album: {
+            name: 'Another Album',
+            release_date: '2023-06-20',
+            images: [{ url: 'https://example.com/image2.jpg' }],
+          },
+        },
+      ],
+    },
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders search form', () => {
+    render(<NewSongForm toggleIsEditing={mockToggleIsEditing} />)
+
+    expect(screen.getByPlaceholderText('Title')).toBeTruthy()
+    expect(screen.getByPlaceholderText('Artist (optional)')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /search/i })).toBeTruthy()
+  })
+
+  it('closes modal when close button is clicked', () => {
+    render(<NewSongForm toggleIsEditing={mockToggleIsEditing} />)
+
+    const closeButton = screen.getAllByRole('button')[0]
+    fireEvent.click(closeButton)
+
+    expect(mockToggleIsEditing).toHaveBeenCalled()
+  })
+
+  it('updates title input on change', async () => {
+    const user = userEvent.setup()
+    render(<NewSongForm toggleIsEditing={mockToggleIsEditing} />)
+
+    const titleInput = screen.getByPlaceholderText('Title') as HTMLInputElement
+    await user.type(titleInput, 'Test Song')
+
+    expect(titleInput.value).toBe('Test Song')
+  })
+
+  it('updates artist input on change', async () => {
+    const user = userEvent.setup()
+    render(<NewSongForm toggleIsEditing={mockToggleIsEditing} />)
+
+    const artistInput = screen.getByPlaceholderText('Artist (optional)') as HTMLInputElement
+    await user.type(artistInput, 'Test Artist')
+
+    expect(artistInput.value).toBe('Test Artist')
+  })
+
+  it('performs search when form is submitted', async () => {
+    const user = userEvent.setup()
+    vi.mocked(Spotify.search).mockResolvedValue(mockSearchResults as any)
+
+    render(<NewSongForm toggleIsEditing={mockToggleIsEditing} />)
+
+    const titleInput = screen.getByPlaceholderText('Title')
+    await user.type(titleInput, 'Test Song')
+
+    const searchButton = screen.getByRole('button', { name: /search/i })
+    await user.click(searchButton)
+
+    await waitFor(() => {
+      expect(Spotify.search).toHaveBeenCalledWith({
+        title: 'Test Song',
+        artist: '',
+      })
+    })
+  })
+
+  it('displays search results after successful search', async () => {
+    const user = userEvent.setup()
+    vi.mocked(Spotify.search).mockResolvedValue(mockSearchResults as any)
+
+    render(<NewSongForm toggleIsEditing={mockToggleIsEditing} />)
+
+    const titleInput = screen.getByPlaceholderText('Title')
+    await user.type(titleInput, 'Test Song')
+
+    const searchButton = screen.getByRole('button', { name: /search/i })
+    await user.click(searchButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Song')).toBeTruthy()
+      expect(screen.getByText('Another Song')).toBeTruthy()
+      expect(screen.getByText('2 results found')).toBeTruthy()
+    })
+  })
+
+  it('shows searching indicator during search', async () => {
+    const user = userEvent.setup()
+    let resolveSearch: any
+    const searchPromise = new Promise((resolve) => {
+      resolveSearch = resolve
+    })
+    vi.mocked(Spotify.search).mockReturnValue(searchPromise as any)
+
+    render(<NewSongForm toggleIsEditing={mockToggleIsEditing} />)
+
+    const titleInput = screen.getByPlaceholderText('Title')
+    await user.type(titleInput, 'Test Song')
+
+    const searchButton = screen.getByRole('button', { name: /search/i })
+    await user.click(searchButton)
+
+    expect(screen.getAllByText(/Searching.../i).length).toBeGreaterThan(0)
+
+    resolveSearch(mockSearchResults)
+
+    await waitFor(() => {
+      expect(screen.queryAllByText(/Searching.../i).length).toBe(0)
+    })
+  })
+
+  it('clears search when clear button is clicked', async () => {
+    const user = userEvent.setup()
+    vi.mocked(Spotify.search).mockResolvedValue(mockSearchResults as any)
+
+    render(<NewSongForm toggleIsEditing={mockToggleIsEditing} />)
+
+    const titleInput = screen.getByPlaceholderText('Title') as HTMLInputElement
+    await user.type(titleInput, 'Test Song')
+
+    const clearButton = screen.getByRole('button', { name: /clear/i })
+    await user.click(clearButton)
+
+    expect(titleInput.value).toBe('')
+  })
+
+  it('saves song when select button is clicked', async () => {
+    const user = userEvent.setup()
+    const { push, set } = await import('firebase/database')
+    vi.mocked(Spotify.search).mockResolvedValue(mockSearchResults as any)
+
+    render(<NewSongForm toggleIsEditing={mockToggleIsEditing} />)
+
+    const titleInput = screen.getByPlaceholderText('Title')
+    await user.type(titleInput, 'Test Song')
+
+    const searchButton = screen.getByRole('button', { name: /search/i })
+    await user.click(searchButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Song')).toBeTruthy()
+    })
+
+    const selectButtons = screen.getAllByRole('button', { name: /select/i })
+    await user.click(selectButtons[0])
+
+    expect(push).toHaveBeenCalled()
+    expect(set).toHaveBeenCalled()
+    expect(mockToggleIsEditing).toHaveBeenCalled()
+  })
+
+  it('displays no results message when search returns empty results', async () => {
+    const user = userEvent.setup()
+    vi.mocked(Spotify.search).mockResolvedValue({ data: { items: [] } } as any)
+
+    render(<NewSongForm toggleIsEditing={mockToggleIsEditing} />)
+
+    const titleInput = screen.getByPlaceholderText('Title')
+    await user.type(titleInput, 'NonexistentSong')
+
+    const searchButton = screen.getByRole('button', { name: /search/i })
+    await user.click(searchButton)
+
+    await waitFor(() => {
+      expect(screen.getByText(/No results found/i)).toBeTruthy()
+    })
+  })
+
+  it('disables search button while searching', async () => {
+    const user = userEvent.setup()
+    let resolveSearch: any
+    const searchPromise = new Promise((resolve) => {
+      resolveSearch = resolve
+    })
+    vi.mocked(Spotify.search).mockReturnValue(searchPromise as any)
+
+    render(<NewSongForm toggleIsEditing={mockToggleIsEditing} />)
+
+    const titleInput = screen.getByPlaceholderText('Title')
+    await user.type(titleInput, 'Test Song')
+
+    const searchButton = screen.getByRole('button', { name: /search/i }) as HTMLButtonElement
+    await user.click(searchButton)
+
+    expect(searchButton.disabled).toBe(true)
+
+    resolveSearch(mockSearchResults)
+
+    await waitFor(() => {
+      expect(searchButton.disabled).toBe(false)
+    })
+  })
+
+  it('renders album artwork when available', async () => {
+    const user = userEvent.setup()
+    vi.mocked(Spotify.search).mockResolvedValue(mockSearchResults as any)
+
+    const { container } = render(<NewSongForm toggleIsEditing={mockToggleIsEditing} />)
+
+    const titleInput = screen.getByPlaceholderText('Title')
+    await user.type(titleInput, 'Test Song')
+
+    const searchButton = screen.getByRole('button', { name: /search/i })
+    await user.click(searchButton)
+
+    await waitFor(() => {
+      const albumImage = container.querySelector('img[alt="Test Album"]') as HTMLImageElement
+      expect(albumImage).toBeTruthy()
+      expect(albumImage.src).toBe('https://example.com/image.jpg')
+    })
+  })
+})

--- a/src/components/SongPage/SongList/useSongs.test.ts
+++ b/src/components/SongPage/SongList/useSongs.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useSongs } from './useSongs'
+import type { Song } from '../../../types'
+import * as reactfire from 'reactfire'
+
+vi.mock('firebase/database', () => ({
+  ref: vi.fn(),
+  query: vi.fn(),
+  orderByChild: vi.fn(),
+}))
+
+describe('useSongs', () => {
+  const mockSongs: Song[] = [
+    {
+      id: '1',
+      title: 'Song A',
+      artist: 'Artist 1',
+      votes: 5,
+      visible: true,
+      addedBy: 'user1',
+    },
+    {
+      id: '2',
+      title: 'Song B',
+      artist: 'Artist 2',
+      votes: 10,
+      visible: true,
+      addedBy: 'user1',
+    },
+    {
+      id: '3',
+      title: 'Song C',
+      artist: 'Artist 3',
+      votes: 3,
+      visible: false,
+      addedBy: 'user1',
+    },
+    {
+      id: '4',
+      title: 'Hidden Song',
+      artist: 'Artist 4',
+      votes: 15,
+      visible: false,
+      addedBy: 'user1',
+    },
+  ]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns empty array when no data is available', () => {
+    vi.spyOn(reactfire, 'useDatabaseListData').mockReturnValue({
+      status: 'loading',
+      data: null,
+    } as any)
+
+    const { result } = renderHook(() => useSongs())
+
+    expect(result.current.songs).toEqual([])
+    expect(result.current.status).toBe('loading')
+  })
+
+  it('sorts songs with visible songs first, then by votes descending', () => {
+    vi.spyOn(reactfire, 'useDatabaseListData').mockReturnValue({
+      status: 'success',
+      data: mockSongs,
+    } as any)
+
+    const { result } = renderHook(() => useSongs())
+
+    expect(result.current.songs).toHaveLength(4)
+    expect(result.current.songs[0].id).toBe('2')
+    expect(result.current.songs[1].id).toBe('1')
+    expect(result.current.songs[2].id).toBe('4')
+    expect(result.current.songs[3].id).toBe('3')
+  })
+
+  it('sorts songs by title when votes are equal', () => {
+    const songsWithEqualVotes: Song[] = [
+      {
+        id: '1',
+        title: 'Zebra',
+        artist: 'Artist 1',
+        votes: 5,
+        visible: true,
+        addedBy: 'user1',
+      },
+      {
+        id: '2',
+        title: 'Apple',
+        artist: 'Artist 2',
+        votes: 5,
+        visible: true,
+        addedBy: 'user1',
+      },
+    ]
+
+    vi.spyOn(reactfire, 'useDatabaseListData').mockReturnValue({
+      status: 'success',
+      data: songsWithEqualVotes,
+    } as any)
+
+    const { result } = renderHook(() => useSongs())
+
+    expect(result.current.songs[0].title).toBe('Apple')
+    expect(result.current.songs[1].title).toBe('Zebra')
+  })
+
+  it('filters songs by search term in title', () => {
+    vi.spyOn(reactfire, 'useDatabaseListData').mockReturnValue({
+      status: 'success',
+      data: mockSongs,
+    } as any)
+
+    const { result } = renderHook(() => useSongs('Song B'))
+
+    expect(result.current.songs).toHaveLength(1)
+    expect(result.current.songs[0].title).toBe('Song B')
+  })
+
+  it('filters songs by search term in artist', () => {
+    vi.spyOn(reactfire, 'useDatabaseListData').mockReturnValue({
+      status: 'success',
+      data: mockSongs,
+    } as any)
+
+    const { result } = renderHook(() => useSongs('Artist 3'))
+
+    expect(result.current.songs).toHaveLength(1)
+    expect(result.current.songs[0].artist).toBe('Artist 3')
+  })
+
+  it('handles empty search filter', () => {
+    vi.spyOn(reactfire, 'useDatabaseListData').mockReturnValue({
+      status: 'success',
+      data: mockSongs,
+    } as any)
+
+    const { result } = renderHook(() => useSongs(''))
+
+    expect(result.current.songs).toHaveLength(4)
+  })
+
+  it('returns success status when data is loaded', () => {
+    vi.spyOn(reactfire, 'useDatabaseListData').mockReturnValue({
+      status: 'success',
+      data: mockSongs,
+    } as any)
+
+    const { result } = renderHook(() => useSongs())
+
+    expect(result.current.status).toBe('success')
+  })
+
+  it('memoizes songs based on data and search filter', () => {
+    vi.spyOn(reactfire, 'useDatabaseListData').mockReturnValue({
+      status: 'success',
+      data: mockSongs,
+    } as any)
+
+    const { result, rerender } = renderHook(
+      ({ filter }) => useSongs(filter),
+      { initialProps: { filter: '' } }
+    )
+
+    const firstResult = result.current.songs
+
+    rerender({ filter: '' })
+
+    expect(result.current.songs).toBe(firstResult)
+  })
+})


### PR DESCRIPTION

- useSongs hook: 8 tests covering sorting, filtering, and memoization (96.66% coverage)
- useShows hook: 5 tests covering data loading and chronological ordering (100% coverage)
- useDeleteShow hook: 4 tests covering Firebase deletion and callback memoization (100% coverage)
- NewSongForm component: 12 tests covering search, form handling, state management, and user interactions (100% coverage)

All new tests follow established patterns using vitest mocking for Firebase hooks and async operations. Tests are isolated, stable, and execute quickly in parallel.